### PR TITLE
SPDX Document Verify and message updates

### DIFF
--- a/src/main/java/org/spdx/library/model/v2/SpdxCreatorInformation.java
+++ b/src/main/java/org/spdx/library/model/v2/SpdxCreatorInformation.java
@@ -261,7 +261,7 @@ public class SpdxCreatorInformation extends ModelObjectV2 {
 		    if (SpdxConstantsCompatV2.LICENSE_LIST_VERSION_PATTERN.matcher(version).matches()) {
 		        return null;
 		    } else {
-		        return "License list version does not match the pattern M.N";
+		        return "License list version does not match the pattern M.N or M.N.P";
 		    }
 		}
 	}

--- a/src/main/java/org/spdx/library/model/v2/SpdxDocument.java
+++ b/src/main/java/org/spdx/library/model/v2/SpdxDocument.java
@@ -133,7 +133,6 @@ public class SpdxDocument extends SpdxElement {
 			}
 			return (SpdxCreatorInformation)retval.get();
 		} else {
-			logger.warn("No creation info for document "+getName());
 			return null;
 		}
 	}
@@ -322,13 +321,10 @@ public class SpdxDocument extends SpdxElement {
 		// documentDescribes relationships
 		try {
 			if (getDocumentDescribes().size() == 0) {
-				retval.add("Document must have at least one relationship of type DOCUMENT_DESCRIBES");
-				// Note - relationships are verified in the superclass.  This should also recursively
-				// verify any other important objects.
-			} else {
-				for (SpdxElement element:getDocumentDescribes()) {
-					retval.addAll(element.verify(verifiedIds, specVersion));
+				if (getModelStore().getAllItems(getDocumentUri(), SpdxConstantsCompatV2.CLASS_SPDX_PACKAGE).count() != 1) {
+					retval.add("Document must have at least one relationship of type DOCUMENT_DESCRIBES or contain only a single SpdxPackage");
 				}
+				// Note - relationships are verified in the superclass which includes the documentDescribes relationship
 			}
 		} catch (InvalidSPDXAnalysisException e) {
 			retval.add("Error getting document describes: "+e.getMessage());

--- a/src/test/java/org/spdx/library/model/compat/v2/SpdxDocumentTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/SpdxDocumentTest.java
@@ -678,5 +678,25 @@ public class SpdxDocumentTest extends TestCase {
 		doc.getDocumentDescribes().remove(describedElement);
 		modelStore.delete(CompatibleModelStoreWrapper.documentUriIdToUri(docUri, describedElementId, false));
 	}
+	
+	// Test for issue 3 - zero document describes with a single package should pass validation
+	public void testSinglePackage() throws InvalidSPDXAnalysisException {
+		IModelStore modelStore = new MockModelStore();
+		String docUri = "https://some.doc.uri";
+		IModelCopyManager copyManager = new MockCopyManager();
+		SpdxDocument doc = new SpdxDocument(modelStore, docUri, copyManager, true);
+		doc.setCreationInfo(doc.createCreationInfo(Arrays.asList(CREATORS1), DATE1));
+		doc.setDataLicense(new SpdxListedLicense(modelStore, docUri, "CC0-1.0", copyManager, true));
+		doc.setName(DOC_NAME1);
+		doc.createPackage(doc.getModelStore().getNextId(IdType.SpdxId),
+				"Package 1", LICENSE1, "Pkg Copyright1", LICENSE2)
+				.setDownloadLocation("hg+https://hg.myproject.org/MyProject#src/somefile.c")
+				.setLicenseComments("Pkg License Comment 1")
+				.setFilesAnalyzed(false)
+				.setVersionInfo("version1")
+				.build();
+		List<String> verify = doc.verify();
+		assertTrue(verify.isEmpty());
+	}
 
 }


### PR DESCRIPTION
Fixes #3

Update SPDX document verify to allow for no document describes if there is only a single package.

Also updates the error message for license list versions to include SEMVER strings.