### PR TITLE
Add InvalidLicenseExpression class

### DIFF
--- a/src/main/java/org/spdx/library/model/v2/SpdxModelFactoryCompatV2.java
+++ b/src/main/java/org/spdx/library/model/v2/SpdxModelFactoryCompatV2.java
@@ -22,6 +22,7 @@ import org.spdx.core.InvalidSPDXAnalysisException;
 import org.spdx.core.SpdxIdNotFoundException;
 import org.spdx.core.TypedValue;
 import org.spdx.library.model.v2.license.AnyLicenseInfo;
+import org.spdx.library.model.v2.license.InvalidLicenseExpression;
 import org.spdx.library.model.v2.license.SpdxListedLicense;
 import org.spdx.storage.IModelStore;
 import org.spdx.storage.IModelStore.IdType;
@@ -104,6 +105,7 @@ public class SpdxModelFactoryCompatV2 {
 		typeToClassV2.put(SpdxConstantsCompatV2.ENUM_REFERENCE_RELATIONSHIP_TYPE, org.spdx.library.model.v2.enumerations.RelationshipType.class);
 		typeToClassV2.put(SpdxConstantsCompatV2.CLASS_EXTERNAL_EXTRACTED_LICENSE, org.spdx.library.model.v2.license.ExternalExtractedLicenseInfo.class);	
 		typeToClassV2.put(SpdxConstantsCompatV2.ENUM_PURPOSE, org.spdx.library.model.v2.enumerations.Purpose.class);
+		typeToClassV2.put(InvalidLicenseExpression.INVALID_LICENSE_EXPRESSION_TYPE, org.spdx.library.model.v2.license.InvalidLicenseExpression.class);
 		SPDX_TYPE_TO_CLASS_V2 = Collections.unmodifiableMap(typeToClassV2);
 		Map<Class<?>, String> classToType = new HashMap<>();
 		for (Entry<String, Class<?>> entry:typeToClassV2.entrySet()) {
@@ -299,5 +301,4 @@ public class SpdxModelFactoryCompatV2 {
 		String type = classUri.substring(indexOfPound+1);
 		return typeToClass(type);
 	}
-
 }

--- a/src/main/java/org/spdx/library/model/v2/license/InvalidLicenseExpression.java
+++ b/src/main/java/org/spdx/library/model/v2/license/InvalidLicenseExpression.java
@@ -1,0 +1,134 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spdx.library.model.v2.license;
+
+import org.spdx.core.IModelCopyManager;
+import org.spdx.core.InvalidSPDXAnalysisException;
+import org.spdx.storage.IModelStore;
+import org.spdx.storage.PropertyDescriptor;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.spdx.library.model.v2.SpdxConstantsCompatV2.SPDX_NAMESPACE;
+
+/**
+ * Represents a license expression string which can not be parsed - used for error handling
+ */
+public class InvalidLicenseExpression extends AnyLicenseInfo {
+
+    public static final PropertyDescriptor MESSAGE_PROPERTY = new PropertyDescriptor("invalidLicenseMessage", SPDX_NAMESPACE);
+    public static final PropertyDescriptor LICENSE_EXPRESSION_PROPERTY = new PropertyDescriptor("invalidLicenseExpression", SPDX_NAMESPACE);
+    public static final String INVALID_LICENSE_EXPRESSION_TYPE = "InvalidLicenseExpression";
+    /**
+     * Create a new InvalidLicenseExpression object
+     * @param modelStore container which includes the license
+     * @param documentUri URI for the SPDX document containing the license
+     * @param id identifier for the license
+     * @param copyManager if non-null, allows for copying of any properties set which use other model stores or document URI's
+     * @param create if true, create the license if it does not exist
+     * @throws InvalidSPDXAnalysisException on error
+     */
+    public InvalidLicenseExpression(IModelStore modelStore, String documentUri, String id,
+                                    @Nullable IModelCopyManager copyManager, boolean create)
+            throws InvalidSPDXAnalysisException {
+        super(modelStore, documentUri, id, copyManager, create);
+    }
+
+    /**
+     * Create a new InvalidLicenseExpression object and initializes the message and licenseExpression
+     * @param modelStore container which includes the license
+     * @param documentUri URI for the SPDX document containing the license
+     * @param id identifier for the license
+     * @param copyManager if non-null, allows for copying of any properties set which use other model stores or document URI's
+     * @param message Error message describing the nature of the invalid license expression
+     * @param licenseExpression License expression string that caused the error
+     * @throws InvalidSPDXAnalysisException on error
+     */
+    public InvalidLicenseExpression(IModelStore modelStore, String documentUri, String id,
+                                    @Nullable IModelCopyManager copyManager, String message,
+                                    String licenseExpression) throws InvalidSPDXAnalysisException {
+        super(modelStore, documentUri, id, copyManager, true);
+        setMessage(message);
+        setLicenseExpression(licenseExpression);
+    }
+
+    @Override
+    protected List<String> _verify(Set<String> verifiedElementIds, String specVersion) {
+        List<String> retval = new ArrayList<>();
+        try {
+            retval.add(String.format("Invalid license expression '%s': %s",
+                    getLicenseExpression(), getMessage()));
+        } catch(Exception e) {
+            retval.add(String.format("Error getting properties: %s", e.getMessage()));
+        }
+        return retval;
+    }
+
+    @Override
+    public String getType() {
+        return INVALID_LICENSE_EXPRESSION_TYPE;
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return getLicenseExpression();
+        } catch (InvalidSPDXAnalysisException e) {
+            return "";
+        }
+    }
+
+    /**
+     * @return the error message associated with the license expression
+     * @throws InvalidSPDXAnalysisException on storage related errors
+     */
+    public String getMessage() throws InvalidSPDXAnalysisException {
+        Optional<String> o = getStringPropertyValue(MESSAGE_PROPERTY);
+        return o.orElse("[Error message not set]");
+    }
+
+    /**
+     * @param message the message to set
+     * @throws InvalidSPDXAnalysisException on storage related errors
+     */
+    public void setMessage(String message) throws InvalidSPDXAnalysisException {
+        setPropertyValue(MESSAGE_PROPERTY, message);
+    }
+
+    /**
+     * @return the license expression which had parsing errors
+     * @throws InvalidSPDXAnalysisException on storage related errors
+     */
+    public String getLicenseExpression() throws InvalidSPDXAnalysisException {
+        Optional<String> o = getStringPropertyValue(LICENSE_EXPRESSION_PROPERTY);
+        return o.orElse("[Error message not set]");
+    }
+
+    /**
+     * @param expression the license expression to set
+     * @throws InvalidSPDXAnalysisException on storage related errors
+     */
+    public void setLicenseExpression(String expression) throws InvalidSPDXAnalysisException {
+        setPropertyValue(LICENSE_EXPRESSION_PROPERTY, expression);
+    }
+}

--- a/src/test/java/org/spdx/library/model/compat/v2/license/InvalidLicenseExpressionTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/license/InvalidLicenseExpressionTest.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spdx.library.model.compat.v2.license;
+
+import junit.framework.TestCase;
+import org.spdx.core.DefaultModelStore;
+import org.spdx.core.InvalidSPDXAnalysisException;
+import org.spdx.core.ModelRegistry;
+import org.spdx.library.model.compat.v2.MockCopyManager;
+import org.spdx.library.model.compat.v2.MockModelStore;
+import org.spdx.library.model.v2.SpdxConstantsCompatV2;
+import org.spdx.library.model.v2.SpdxModelFactoryCompatV2;
+import org.spdx.library.model.v2.SpdxModelInfoV2_X;
+import org.spdx.library.model.v2.license.ExtractedLicenseInfo;
+import org.spdx.library.model.v2.license.InvalidLicenseExpression;
+import org.spdx.storage.IModelStore;
+
+import java.util.List;
+
+public class InvalidLicenseExpressionTest extends TestCase {
+
+    /* (non-Javadoc)
+     * @see junit.framework.TestCase#setUp()
+     */
+    protected void setUp() throws Exception {
+        super.setUp();
+        ModelRegistry.getModelRegistry().registerModel(new SpdxModelInfoV2_X());
+        DefaultModelStore.initialize(new MockModelStore(), "http://defaultdocument", new MockCopyManager());
+    }
+
+    /* (non-Javadoc)
+     * @see junit.framework.TestCase#tearDown()
+     */
+    protected void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    public void testInvalidLicenseExpressionMessageLicenseExpression() throws InvalidSPDXAnalysisException {
+        String message = "error message";
+        String expression = "license expression";
+        String id = DefaultModelStore.getDefaultModelStore().getNextId(IModelStore.IdType.Anonymous);
+        InvalidLicenseExpression inv1 = new InvalidLicenseExpression(DefaultModelStore.getDefaultModelStore(), DefaultModelStore.getDefaultDocumentUri(),
+                id, DefaultModelStore.getDefaultCopyManager(), message, expression);
+
+        InvalidLicenseExpression inv2 = (InvalidLicenseExpression) SpdxModelFactoryCompatV2.createModelObjectV2(DefaultModelStore.getDefaultModelStore(), DefaultModelStore.getDefaultDocumentUri(),
+                id, InvalidLicenseExpression.INVALID_LICENSE_EXPRESSION_TYPE, DefaultModelStore.getDefaultCopyManager());
+        assertEquals(message, inv2.getMessage());
+        assertEquals(expression, inv2.getLicenseExpression());
+        List<String> verify = inv2.verify();
+        assertEquals(1, verify.size());
+        assertTrue(verify.get(0).contains(message));
+        assertTrue(verify.get(0).contains(expression));
+    }
+
+}


### PR DESCRIPTION
Supports improvements to the license parsing error handling.

See https://github.com/spdx/Spdx-Java-Library/pull/339 for reference.