### PR TITLE
Fix an issues with `SpdxPackage._verify()`

### DIFF
--- a/src/main/java/org/spdx/library/model/v2/SpdxPackage.java
+++ b/src/main/java/org/spdx/library/model/v2/SpdxPackage.java
@@ -608,11 +608,7 @@ public class SpdxPackage extends SpdxItem implements Comparable<SpdxPackage> {
 		
 		// files depends on if the filesAnalyzed flag
 		try {
-			if (getFiles().size() == 0) {
-				if (filesAnalyzed) {
-					retval.add("Missing required package files for "+pkgName);
-				}
-			} else {
+			if (!getFiles().isEmpty()) {
 				if (!filesAnalyzed) {
 					retval.add("Warning: Found analyzed files for package "+pkgName+" when analyzedFiles is set to false.");
 				}


### PR DESCRIPTION
The specification for SPDX v2.3 seems to not require that for each `SpdxPackage` all files which in reality correspond to that package have to be included as `SpdxFile` in case files have been analyzed, namely `filesAnalyzed` is set to `true` [1]. This allows the freedom for the creator of on SPDX document to only selectively include certain files. For example, a tool may analyze all files of a package for license texts, but choose to only selectively include certain files containing license texts as `SpdxFile` entry into the SPDX document, for example to reduce the size of the SPDX document a bit, or to omit information which is less relevant in the given context.

This implies, that it should also be valid to not include any files for a package even though its files have been analyzed. However, `_verify()` complains if `filesAnalyzed && files.size() == 0` which seems incorrect. Drop that check to align with the spec.

[1] https://spdx.github.io/spdx-spec/v2.3/package-information/#78-files-analyzed-field