### PR TITLE
Fix create model object for extracted licenses

### DIFF
--- a/src/main/java/org/spdx/library/model/v2/SpdxConstantsCompatV2.java
+++ b/src/main/java/org/spdx/library/model/v2/SpdxConstantsCompatV2.java
@@ -346,7 +346,8 @@ public class SpdxConstantsCompatV2 {
 	public static Pattern LICENSE_ID_PATTERN_NUMERIC = 
 			Pattern.compile(NON_STD_LICENSE_ID_PRENUM+"(\\d+)$");	// Pattern for numeric only license IDs
 	public static Pattern LICENSE_ID_PATTERN = Pattern.compile(NON_STD_LICENSE_ID_PRENUM+"([0-9a-zA-Z\\.\\-\\_]+)\\+?$");
-	
+	public static Pattern EXTRACTED_LICENSE_URI_PATTERN = Pattern.compile("(.+)#("+NON_STD_LICENSE_ID_PRENUM+"[0-9a-zA-Z\\.\\-\\+]+)$");
+
 	// SPDX Element Reference format
 	public static String SPDX_ELEMENT_REF_PRENUM = "SPDXRef-";
 	public static Pattern SPDX_ELEMENT_REF_PATTERN = Pattern.compile(SPDX_ELEMENT_REF_PRENUM+"([0-9a-zA-Z\\.\\-\\+]+)$");

--- a/src/main/java/org/spdx/library/model/v2/SpdxModelInfoV2_X.java
+++ b/src/main/java/org/spdx/library/model/v2/SpdxModelInfoV2_X.java
@@ -173,10 +173,10 @@ public class SpdxModelInfoV2_X implements ISpdxModelInfo {
 				logger.error("Extracted licenses must not be anonymous types - missing ID for "+objectUri);
 				throw new InvalidSPDXAnalysisException("Extracted licenses must not be anonymous types - missing ID for "+objectUri);
 			}
-			Matcher matcher = SpdxConstantsCompatV2.EXTERNAL_EXTRACTED_LICENSE_URI_PATTERN.matcher(objectUri);
+			Matcher matcher = SpdxConstantsCompatV2.EXTRACTED_LICENSE_URI_PATTERN.matcher(objectUri);
 			if (!matcher.matches()) {
 				throw new InvalidSPDXAnalysisException("ExtractedLicenseInfo object URI does not follow the SPDX V2.X required pattern" + 
-						SpdxConstantsCompatV2.EXTERNAL_EXTRACTED_LICENSE_URI_PATTERN);
+						SpdxConstantsCompatV2.EXTRACTED_LICENSE_URI_PATTERN);
 			}
 			return SpdxModelFactoryCompatV2.getModelObjectV2(modelStore, matcher.group(1), matcher.group(2), type, copyManager, create);
 		} else {

--- a/src/test/java/org/spdx/library/model/compat/v2/SpdxModelInfoV2_XTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/SpdxModelInfoV2_XTest.java
@@ -25,11 +25,10 @@ import org.spdx.library.model.v2.SpdxNone;
 import org.spdx.library.model.v2.SpdxNoneElement;
 import org.spdx.library.model.v2.SpdxPackage;
 import org.spdx.library.model.v2.Version;
-import org.spdx.library.model.v2.license.AnyLicenseInfo;
-import org.spdx.library.model.v2.license.ExternalExtractedLicenseInfo;
-import org.spdx.library.model.v2.license.SpdxNoAssertionLicense;
-import org.spdx.library.model.v2.license.SpdxNoneLicense;
+import org.spdx.library.model.v2.license.*;
 import org.spdx.storage.IModelStore;
+
+import java.util.Collections;
 
 /**
  * @author gary
@@ -110,6 +109,30 @@ public class SpdxModelInfoV2_XTest {
 		assertTrue(result instanceof SpdxPackage);
 		assertEquals(objectUri, result.getObjectUri());
 		assertEquals("http://prefix#", result.getIdPrefix());
+
+		// Test Listed License
+		SpdxListedLicense stdl = new SpdxListedLicense("Apache 2.0", "Apache-2.0", "text",
+				Collections.EMPTY_LIST, "notes", "standardLicenseHeader", "template", true, true, "licenseHtml", false, null);
+		result = modelInfo.createModelObject(modelStore, stdl.getObjectUri(), SpdxConstantsCompatV2.CLASS_SPDX_LISTED_LICENSE, copyManager, Version.TWO_POINT_THREE_VERSION,
+				false, "http://spdx.org/licenses");
+		assertTrue(result instanceof SpdxListedLicense);
+		assertEquals("Apache-2.0", result.getId());
+		// Test Extracted License
+
+		objectUri = prefix + "#" + SpdxConstantsCompatV2.NON_STD_LICENSE_ID_PRENUM + "test";
+		result = modelInfo.createModelObject(modelStore, objectUri, SpdxConstantsCompatV2.CLASS_SPDX_EXTRACTED_LICENSING_INFO, copyManager, Version.TWO_POINT_THREE_VERSION,
+				true, prefix);
+		assertTrue(result instanceof ExtractedLicenseInfo);
+		assertEquals(SpdxConstantsCompatV2.NON_STD_LICENSE_ID_PRENUM + "test", result.getId());
+
+		// Test License Exception
+		ListedLicenseException le = new ListedLicenseException("exceptionId",
+				"exception name", "EXCEPTION_TEXT1", Collections.EMPTY_LIST,
+				"EXCEPTION_COMMENT1");
+		result = modelInfo.createModelObject(modelStore, le.getObjectUri(), SpdxConstantsCompatV2.CLASS_SPDX_LISTED_LICENSE_EXCEPTION, copyManager, Version.TWO_POINT_THREE_VERSION,
+				false, "http://spdx.org/licenses");
+		assertTrue(result instanceof ListedLicenseException);
+		assertEquals("exceptionId", result.getId());
 	}
 
 }


### PR DESCRIPTION
Fixes an issue when using the CreateModelObject for extracted licenses